### PR TITLE
#fix daily checkup #52

### DIFF
--- a/src/entrypoints/api/routers/daily_checkup.py
+++ b/src/entrypoints/api/routers/daily_checkup.py
@@ -6,6 +6,7 @@ from datetime import date
 
 from src.container import container
 from src.entrypoints.api.deps.auth import get_current_user, require_owner_or_admin
+from src.entrypoints.api.deps.roles import require_roles
 from src.entrypoints.api.schemas.daily_checkup import DailyCheckupCreate, DailyCheckupRead
 from src.domain.exceptions import NotFoundError, ValidationError
 
@@ -73,6 +74,18 @@ async def create_daily_checkup(
 async def get_my_daily_checkups(user=Depends(get_current_user)):
     service = container.get_daily_checkup_service()
     checkups = await service.get_by_profile_id(UUID(user["sub"]))
+    return [DailyCheckupRead.model_validate(checkup) for checkup in checkups]
+
+@router.get(
+    "/user/{user_id}",
+    response_model=List[DailyCheckupRead],
+    dependencies=[Depends(require_roles("admin", "coach"))]
+)
+async def get_user_daily_checkups(
+    user_id: UUID,
+):
+    service = container.get_daily_checkup_service()
+    checkups = await service.get_by_profile_id(user_id)
     return [DailyCheckupRead.model_validate(checkup) for checkup in checkups]
 
 @router.get("/today", response_model=Optional[DailyCheckupRead])

--- a/src/entrypoints/api/routers/diet.py
+++ b/src/entrypoints/api/routers/diet.py
@@ -57,6 +57,19 @@ async def update_diet(diet_id: UUID,
         raise HTTPException(status_code=HTTP_404_NOT_FOUND, detail="Diet not found")
     return DietRead.model_validate(updated)
 
+@router.get(
+    "/{diet_id}",
+    response_model=DietRead,
+    dependencies=[Depends(get_current_user)]
+)
+async def get_diet(diet_id: UUID):
+    svc = container.get_diet_service()
+    try:
+        diet = await svc.get_diet(diet_id)
+    except NotFoundError:
+        raise HTTPException(status_code=HTTP_404_NOT_FOUND, detail="Diet not found")
+    return DietRead.model_validate(diet)
+
 @router.delete("/{diet_id}/user/{target_user_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_diet(diet_id: UUID,
                 _=Depends(require_coach_for_user_or_admin)):


### PR DESCRIPTION
close #52 

@changelog
## [Task] - API Endpoints Enhancement

### 🚀 Task Added

#### Addition of Two New API Endpoints

- **Daily Checkup Retrieval Endpoint**
  - **Purpose:** Allows retrieval of the daily checkup data for a targeted user.
  - **Access Control:** Restricted to users with Admin or Coach roles only.
  - **Description:** This endpoint enables authorized personnel to obtain detailed daily checkup information for any specified user, supporting enhanced monitoring and personalized coaching.

- **Single Diet Retrieval Endpoint**
  - **Purpose:** Enables fetching the details of a single diet entry.
  - **Description:** Provides an endpoint to retrieve all information related to a specific diet, improving data access and management for diet-related features.

---